### PR TITLE
Skip job dependencies for deployment stages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -88,6 +88,7 @@ publish:
 staging:
   stage: staging
   image: registry.satoshipay.tech/infrastructure/docker/helmfile:latest
+  dependencies: []
   environment:
     name: staging
     url: https://signature-coordinator.staging.satoshipay.tech
@@ -102,6 +103,7 @@ staging:
 production:
   stage: production
   image: registry.satoshipay.tech/infrastructure/docker/helmfile:latest
+  dependencies: []
   variables:
     INGRESS_CLASS: traefik
   environment:


### PR DESCRIPTION
Fixes the issue whereby production deployments can only be executed up to one hour after the `prepare` job has completed.