### PR TITLE
Enable switching to HAProxy

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -105,7 +105,7 @@ production:
   image: registry.satoshipay.tech/infrastructure/docker/helmfile:latest
   dependencies: []
   variables:
-    INGRESS_CLASS: '""'
+    INGRESS_CLASS: core
   environment:
     name: production
     url: https://multisig.satoshipay.io


### PR DESCRIPTION
On staging, this will switch to HAProxy on deployment, which will break until the DNS entry is updated.

On production, this will only be *possible* once this PR is merged and deployed. Afterwards, the DNS entry will need to point to the HAProxy instance instead of Traefik, but Traefik will continue to work in the meantime.