### PR TITLE
Add gcp-get-secret to docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,5 +45,5 @@ COPY --from=builder /app/node_modules /app/node_modules
 
 EXPOSE 3000
 
-ENTRYPOINT "/usr/local/bin/gcp-get-secret"
-CMD "node" "./build/index.js"
+ENTRYPOINT [ "/usr/local/bin/gcp-get-secret" ]
+CMD [ "node", "./build/index.js" ]


### PR DESCRIPTION
Adds https://github.com/binxio/gcp-get-secret to the docker image, so we can use the Google Cloud Secret Manager in a transparent way.